### PR TITLE
Add KWS Age spoofer

### DIFF
--- a/src/AccountPatches.cs
+++ b/src/AccountPatches.cs
@@ -1,9 +1,192 @@
 using AmongUs.Data.Player;
 using HarmonyLib;
+using Epic.OnlineServices;
+using Epic.OnlineServices.KWS;
 
 namespace AUnlocker;
 
 // Some of the below patches are from https://github.com/scp222thj/MalumMenu/
+
+[HarmonyPatch(typeof(KWSInterface), nameof(KWSInterface.QueryAgeGate))]
+public static class QueryAgeGate_KWSInterface_QueryAgeGate_Prefix
+{
+    /// <summary>
+    /// Spoof age gate queries to return adult status.
+    /// </summary>
+    /// <param name="options">Query options.</param>
+    /// <param name="clientData">Client data.</param>
+    /// <param name="completionDelegate">Completion callback.</param>
+    /// <returns><c>false</c> to skip the original method, <c>true</c> to allow the original method to run.</returns>
+    public static bool Prefix(ref QueryAgeGateOptions options, object clientData, OnQueryAgeGateCallback completionDelegate)
+    {
+        if (!AUnlocker.UnlockMinor.Value) return true;
+
+        try
+        {
+            var spoofedInfo = new QueryAgeGateCallbackInfo
+            {
+                ResultCode = Result.Success,
+                CountryCode = (Utf8String)"US",
+                AgeOfConsent = 18
+            };
+
+            completionDelegate?.Invoke(ref spoofedInfo);
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}
+
+[HarmonyPatch(typeof(KWSInterface), nameof(KWSInterface.QueryPermissions))]
+public static class QueryPermissions_KWSInterface_QueryPermissions_Prefix
+{
+    /// <summary>
+    /// Spoof permission queries to return adult status.
+    /// </summary>
+    /// <param name="options">Query options.</param>
+    /// <param name="clientData">Client data.</param>
+    /// <param name="completionDelegate">Completion callback.</param>
+    /// <returns><c>false</c> to skip the original method, <c>true</c> to allow the original method to run.</returns>
+    public static bool Prefix(ref QueryPermissionsOptions options, object clientData, OnQueryPermissionsCallback completionDelegate)
+    {
+        if (!AUnlocker.UnlockMinor.Value) return true;
+
+        try
+        {
+            var spoofedInfo = new QueryPermissionsCallbackInfo
+            {
+                ResultCode = Result.Success,
+                IsMinor = false,
+                DateOfBirth = (Utf8String)"1990-01-01",
+                ParentEmail = (Utf8String)"verified@parental-consent.com"
+            };
+
+            completionDelegate?.Invoke(ref spoofedInfo);
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}
+
+[HarmonyPatch(typeof(KWSInterface), nameof(KWSInterface.GetPermissionByKey))]
+public static class GetPermissionByKey_KWSInterface_GetPermissionByKey_Prefix
+{
+    /// <summary>
+    /// Spoof permission checks to always return granted.
+    /// </summary>
+    /// <param name="options">Query options.</param>
+    /// <param name="outPermission">Output permission status.</param>
+    /// <param name="__result">Original return value.</param>
+    /// <returns><c>false</c> to skip the original method, <c>true</c> to allow the original method to run.</returns>
+    public static bool Prefix(ref GetPermissionByKeyOptions options, out KWSPermissionStatus outPermission, ref Result __result)
+    {
+        if (AUnlocker.UnlockMinor.Value)
+        {
+            outPermission = KWSPermissionStatus.Granted;
+            __result = Result.Success;
+            return false;
+        }
+        
+        outPermission = default;
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(KWSInterface), nameof(KWSInterface.CopyPermissionByIndex))]
+public static class CopyPermissionByIndex_KWSInterface_CopyPermissionByIndex_Prefix
+{
+    /// <summary>
+    /// Spoof indexed permission lookups to always return granted.
+    /// </summary>
+    /// <param name="options">Query options.</param>
+    /// <param name="outPermission">Output permission status.</param>
+    /// <param name="__result">Original return value.</param>
+    /// <returns><c>false</c> to skip the original method, <c>true</c> to allow the original method to run.</returns>
+    public static bool Prefix(ref CopyPermissionByIndexOptions options, out PermissionStatus outPermission, ref Result __result)
+    {
+        if (AUnlocker.UnlockMinor.Value)
+        {
+            outPermission = new PermissionStatus
+            {
+                Status = KWSPermissionStatus.Granted
+            };
+            __result = Result.Success;
+            return false;
+        }
+        
+        outPermission = default;
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(KWSInterface), nameof(KWSInterface.RequestPermissions))]
+public static class RequestPermissions_KWSInterface_RequestPermissions_Prefix
+{
+    /// <summary>
+    /// Spoof permission requests to always return success.
+    /// </summary>
+    /// <param name="options">Request options.</param>
+    /// <param name="clientData">Client data.</param>
+    /// <param name="completionDelegate">Completion callback.</param>
+    /// <returns><c>false</c> to skip the original method, <c>true</c> to allow the original method to run.</returns>
+    public static bool Prefix(ref RequestPermissionsOptions options, object clientData, OnRequestPermissionsCallback completionDelegate)
+    {
+        if (!AUnlocker.UnlockMinor.Value) return true;
+
+        try
+        {
+            var spoofedInfo = new RequestPermissionsCallbackInfo
+            {
+                ResultCode = Result.Success
+            };
+
+            completionDelegate?.Invoke(ref spoofedInfo);
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}
+
+[HarmonyPatch(typeof(KWSInterface), nameof(KWSInterface.CreateUser))]
+public static class CreateUser_KWSInterface_CreateUser_Prefix
+{
+    /// <summary>
+    /// Spoof user creation to return adult status.
+    /// </summary>
+    /// <param name="options">Creation options.</param>
+    /// <param name="clientData">Client data.</param>
+    /// <param name="completionDelegate">Completion callback.</param>
+    /// <returns><c>false</c> to skip the original method, <c>true</c> to allow the original method to run.</returns>
+    public static bool Prefix(ref CreateUserOptions options, object clientData, OnCreateUserCallback completionDelegate)
+    {
+        if (!AUnlocker.UnlockMinor.Value) return true;
+
+        try
+        {
+            var spoofedInfo = new CreateUserCallbackInfo
+            {
+                ResultCode = Result.Success,
+                IsMinor = false
+            };
+
+            completionDelegate?.Invoke(ref spoofedInfo);
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}
 
 [HarmonyPatch(typeof(EOSManager), nameof(EOSManager.IsFreechatAllowed))]
 public static class UnlockFreechat_EOSManager_IsFreechatAllowed_Postfix


### PR DESCRIPTION
Pretty shit, vibecoded have to admit it but it works

<!--- Provide a general summary of your changes in the Title above -->

## What type of PR is this? (check all applicable)

<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor / Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail. You can also include screenshots here. -->
Added a spoofer for the Guardian system Among Us has. Have to admit this was vibecoded and you can close it but I hope it is useful to someone who is having this issue, I guess.

## Context

<!--- Why is this change required? What problem does it solve? -->
Sometimes Among Us won't send the Guardian email, making it impossible to verify your age and to get Free Chat/Or trying to change your username.
<!--
For pull requests that relate or close an issue, please include them
below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will
automatically close the issue.
-->

## Checklist

<!--- Put an `x` in all the boxes that apply -->

- [x] I have verified my changes work
- [x] I have added an explanation of what my changes do
- [x] My code follows the code style of this project