### PR TITLE
Add Classic / Nostalgia Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
   - Remove the 60 FPS cap
   - Resize the in-game buttons (Use, Kill, Report, etc.)
   - Prevent the game from collecting analytics and sending them to Innersloth
-  - Be able to activate the April Fools Mode (Seeker, Long Boi and Horse Mode)
+  - Enable April Fools Mode (Choose between Classic / Nostalgia, Seeker, Long Boi and Horse Mode)
   - Show more information when finding a game: host name, lobby code, host platform, lobby age, and exact number of lobbies online
   - Always display the timer in the bottom left corner to indicate when the server will close the lobby (Works only as Host)
   - Show the task panel (contains a list of your tasks) during meetings

--- a/src/AUnlocker.cs
+++ b/src/AUnlocker.cs
@@ -71,7 +71,7 @@ public partial class AUnlocker : BasePlugin
         // Other
         UnlockFPS = Config.Bind("Other", "FPS", 60, "Set the game's FPS cap to this value");
         DisableTelemetry = Config.Bind("Other", "DisableTelemetry", true, "Prevent the game from collecting analytics and sending them to Innersloth");
-        AprilFoolsMode = Config.Bind("Other", "AprilFoolsMode", "Disabled", "Enable April Fools Mode (only client-side)\n\nOptions: Disabled, Horse, Seeker, Long, LongHorse");
+        AprilFoolsMode = Config.Bind("Other", "AprilFoolsMode", "Disabled", "Enable April Fools Mode (only client-side)\n\nOptions: Disabled, Horse, Seeker, Long, LongHorse, Classic");
         MoreLobbyInfo = Config.Bind("Other", "MoreLobbyInfo", false, "Show more information when finding a game: host name (e.g. Astral), lobby code (e.g. KLHCEG), host platform (e.g. Epic), " +
                                                                      "and lobby age in minutes (e.g. 4:20).\nAdditionally, display the exact number of lobbies online instead of an approximation like '500+'");
         AlwaysShowLobbyTimer = Config.Bind("Other", "AlwaysShowLobbyTimer", false, "Always display the timer in the bottom left corner to indicate when the server will close the lobby (Works only as Host)");

--- a/src/OtherPatches.cs
+++ b/src/OtherPatches.cs
@@ -40,6 +40,9 @@ public static class AprilFoolsMode_PlayerControl_BodyType_Prefix
             case "LongHorse":
                 __result = PlayerBodyTypes.LongSeeker;
                 return false;
+			case "Classic":
+                __result = PlayerBodyTypes.Classic;
+                return false;
             default:
                 return true;
         }
@@ -57,6 +60,7 @@ public static class AprilFoolsMode_PlayerPhysics_SetBodyType_Prefix
             "Seeker" => PlayerBodyTypes.Seeker,
             "Long" => PlayerBodyTypes.Long,
             "LongHorse" => PlayerBodyTypes.LongSeeker,
+			"Classic" => PlayerBodyTypes.Classic,
             _ => bodyType
         };
     }


### PR DESCRIPTION
First time doing this so hopefully I have everything correct

## Description

added the "Classic" player body type into 

[switch (AUnlocker.AprilFoolsMode.Value) ] 
<img width="1072" height="553" alt="Btype2" src="https://github.com/user-attachments/assets/778696af-df92-4e6d-a591-7c13f8116f9d" />

[bodyType = AUnlocker.AprilFoolsMode.Value switch]
<img width="590" height="284" alt="Btype3" src="https://github.com/user-attachments/assets/28ac26cd-74b9-46d1-894a-e5636151dcfd" />

This enables the Old Models used from Nostalga Mode via the AUnlocker.cfg with "Classic"
<img width="327" height="242" alt="NS Mode" src="https://github.com/user-attachments/assets/b0ede344-2e65-46d1-a8ac-a3fea53cd0ce" />

## Context

Nostalgia Mode April Fools
(https://github.com/astra1dev/AUnlocker/issues/119)

## Checklist

<!--- Put an `x` in all the boxes that apply -->

- [x] I have verified my changes work
- [x] I have added an explanation of what my changes do
- [x] My code follows the code style of this project